### PR TITLE
Run push from cli code.

### DIFF
--- a/actions/deploy.go
+++ b/actions/deploy.go
@@ -100,13 +100,10 @@ func Deploy(c *h.Context, w http.ResponseWriter, r *http.Request) {
 
 func getArchiveURL(client *github.Client, user, repo, ref string) (string, error) {
 	opts := &github.RepositoryContentGetOptions{Ref: ref}
-	log.Println(user, repo, opts)
-	url, foo, err := client.Repositories.GetArchiveLink(user, repo, "tarball", opts)
-	log.Println(foo)
+	url, _, err := client.Repositories.GetArchiveLink(user, repo, "tarball", opts)
 	if err != nil {
 		return "", err
 	}
-	log.Println(url)
 	return url.String(), nil
 }
 


### PR DESCRIPTION
Run push command directly from cf cli code instead of shelling out to the compiled cli. This is less of a hack than before, and we still get the same behavior as `cf push` without having to reimplement.

wdyt @dlapiduz?